### PR TITLE
Disable autoescape for page js

### DIFF
--- a/src/bucketgames/templates/bucket.html
+++ b/src/bucketgames/templates/bucket.html
@@ -44,7 +44,9 @@
 
     <script src="/_static/bootstrap.bundle.min.js"></script>
     <script src="script.js"></script>
-    <script>{{ page.js }}</script>
+    <script>
+        {% autoescape false %}{{ page.js }}{% endautoescape %}
+    </script>
 </body>
 
 </html>

--- a/src/bucketgames/templates/game.html
+++ b/src/bucketgames/templates/game.html
@@ -102,7 +102,9 @@
 
     <script src="/_static/bootstrap.bundle.min.js"></script>
     <script src="script.js"></script>
-    <script>{{ page.js }}</script>
+    <script>
+        {% autoescape false %}{{ page.js }}{% endautoescape %}
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
This PR fixes a bug where certain characters in Javascript content, such as quotes, are escaped by Jinja and cause syntax errors.

### Security considerations

This PR will disable all escaping for Javascript content.  
If the content can be manipulated by a malicious party, then the party will have access to the page HTML by inserting the `</script>` tag. However, access to Javascript already implies access to page HTML. 

This PR assumes that only trusted parties will have access to Javascript configuration.